### PR TITLE
Update threadpool.asciidoc target_response_time

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -120,7 +120,7 @@ The `auto_queue_frame_size` setting controls the number of operations during
 which measurement is taken before the queue is adjusted. It should be large
 enough that a single operation cannot unduly bias the calculation.
 
-The `target_response_rate` is a time value setting that indicates the targeted
+The `target_response_time` is a time value setting that indicates the targeted
 average response time for tasks in the thread pool queue. If tasks are routinely
 above this time, the thread pool queue will be adjusted down so that tasks are
 rejected.
@@ -134,7 +134,7 @@ thread_pool:
         min_queue_size: 10
         max_queue_size: 1000
         auto_queue_frame_size: 2000
-        target_response_rate: 1s
+        target_response_time: 1s
 --------------------------------------------------
 
 [float]


### PR DESCRIPTION
Update doc to use correct param name "target_reponse_time"
source => https://github.com/elastic/elasticsearch/blob/6.2/server/src/main/java/org/elasticsearch/threadpool/AutoQueueAdjustingExecutorBuilder.java#L65

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
